### PR TITLE
Added info command to get more info than just the latest

### DIFF
--- a/sub.py
+++ b/sub.py
@@ -210,6 +210,40 @@ class Sub:
         return self._data
 
     # ---------- display ----------
+    @property
+    def detailed_info(self) -> str:
+        """Provides a detailed 
+           list of the attributes of the 
+           sub. Used if the user wants 
+           to see how the sub is configured 
+           like its update frequency and 
+           other aspects not displayed typically
+
+        Returns:
+            str: detailed description of the sub
+        """
+        details_str = (f"{self.name}'s Detailed Information:\n"
+                       f"\tHandle: {self.handle}\n"
+                       f"\tChannel Id: {self._data['id']}\n"
+                       f"\tUploads Id: {self.uploads_id}\n"
+                       f"\tUpdate Frequency: {self.update_frequency}\n"
+                       f"\tWatched Latest: {self.watched}\n"
+                       f"\tNot Intersted in Latest: {self.not_interested}\n")
+
+        if "latest upload" not in self._data.keys():
+            return details_str
+
+        # this block is added if the sub has data on the latest
+        # video from the channel
+        duration = isodate.parse_duration(self._data['duration'])
+
+        return details_str + (
+            f"\tLatest Video Details:\n"
+            f"\t\tTitle: {self._data['latest upload']}\n"
+            f"\t\tDuration: {duration}\n"
+            f"\t\tUrl: {self._data['latest video url']}\n"
+            f"\t\tUpload Date and Time: {self.latest_upload_time}"
+        )
 
     def __str__(self) -> str:
         duration = self._data.get("duration", "Unknown")

--- a/subber.py
+++ b/subber.py
@@ -160,7 +160,7 @@ def parse_arguments(parser:argparse.ArgumentParser, subs:SubscriptionList):
             play_latest(args.play[0], subs)
         except VideoPlayerException as e:
             print(e.msg)
-    
+
     if isinstance(args.info, list):
         get_information_on_subs(args.info, subs)
 
@@ -234,7 +234,7 @@ def main():
                         nargs=1,
                         help="play the latest video from the given channel",
                         metavar="<channel handle>")
-    
+
     parser.add_argument("-i",
                         "--info",
                         type=str,

--- a/subber.py
+++ b/subber.py
@@ -104,6 +104,23 @@ def play_latest(handle:str, subs:SubscriptionList):
     else:
         raise VideoPlayerException(f"Not subscribed to the handle {handle}")
 
+def get_information_on_subs(handles:list[str], subs:SubscriptionList):
+    """List the detailed information about the given
+       list of youtube channels given by the handles
+
+    Args:
+        handles (list[str]): a list of youtube
+        channel handles to information about
+        subs (SubscriptionList): subscription list manager object
+    """
+    for handle in handles:
+        sub = subs.get_sub(handle)
+        if sub is not None:
+            print(sub.detailed_info)
+        else:
+            print(f"You are not subscribed to a channel with the handle: {handle}")
+        print("") # adds new line
+
 
 def parse_arguments(parser:argparse.ArgumentParser, subs:SubscriptionList):
     """Parse the arguments given from the command line
@@ -143,6 +160,9 @@ def parse_arguments(parser:argparse.ArgumentParser, subs:SubscriptionList):
             play_latest(args.play[0], subs)
         except VideoPlayerException as e:
             print(e.msg)
+    
+    if isinstance(args.info, list):
+        get_information_on_subs(args.info, subs)
 
 
 def main():
@@ -214,6 +234,13 @@ def main():
                         nargs=1,
                         help="play the latest video from the given channel",
                         metavar="<channel handle>")
+    
+    parser.add_argument("-i",
+                        "--info",
+                        type=str,
+                        nargs='*',
+                        help="Get the information for the given channel or channels",
+                        metavar="<channel handle(s)>")
 
     if len(sys.argv) == 1:
         parser.print_help()


### PR DESCRIPTION
This is the solution to the issue of not being able to see more info about channels. Instead of listing all the channels I am choosing to let the user decide because this makes more sense for the command flow. Right now, subs -l gets very long and that is unavoidable, so instead of having to scroll up to see the channel. type the subs -i to see the info so its easier to see the handle needed to type to play the latest. 